### PR TITLE
Edits based on dnsop feedback

### DIFF
--- a/draft-song-dns-wireformat-http-01.txt
+++ b/draft-song-dns-wireformat-http-01.txt
@@ -68,7 +68,8 @@ Table of Contents
      3.3.  Message Body  . . . . . . . . . . . . . . . . . . . . . .   6
    4.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
    5.  IANA considerations . . . . . . . . . . . . . . . . . . . . .   7
-   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
+   6.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .   7
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   8
 
 1.  Introduction
@@ -104,8 +105,7 @@ Table of Contents
    advanced usage in application development in mind (although it is
    possible for a web browser to use this protocol to perform DNS
    lookups, for example via JavaScript code).  The protocol is intended
-   to serve as a sort of DNS VPN, and does not introduce another format
-   of DNS data.
+
 
 
 
@@ -113,6 +113,9 @@ Song, et al.           Expires September 11, 2016               [Page 2]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   to serve as a sort of DNS VPN, and does not introduce another format
+   of DNS data.
 
    This memo aims to describe how the DNS binary over HTTP concept
    works.  Hopefully implementations by different developers following
@@ -160,15 +163,15 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
    1.  The stub-resolver sends a DNS query (over UDP or TCP) to the
        proxy client.
 
-   2.  The proxy client encapsulates the DNS message in an HTTP message
-       body and assigns parameters with the HTTP header.
-
 
 
 Song, et al.           Expires September 11, 2016               [Page 3]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   2.  The proxy client encapsulates the DNS message in an HTTP message
+       body and assigns parameters with the HTTP header.
 
    3.  The proxy client connects to the proxy server and issues an HTTP
        POST request method.  This may re-use an existing HTTP
@@ -215,9 +218,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
    optionally returns a human-readable page showing its web server
    environment.
 
-   Usually the target URI is provides explicitly by the DNS services
-   provider.  Derived from the target URI, the request-target in
-   request-line identifies the target resource upon which to apply the
 
 
 
@@ -226,6 +226,9 @@ Song, et al.           Expires September 11, 2016               [Page 4]
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
+   Usually the target URI is provides explicitly by the DNS services
+   provider.  Derived from the target URI, the request-target in
+   request-line identifies the target resource upon which to apply the
    request.  In the case of DNS query over HTTP, one approach is to
    always use a fixed string for request-target by default, like "/dns-
    over-http".  It works if there is no other resource sharing the same
@@ -271,9 +274,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
 
    Proxy-DNS-Transport: xyz
 
-   Where xyz is either UDP or TCP, which is the client's indication of
-   how it received the underlying DNS query, and which the server will
-   use when sending the query to the far-end DNS server.  This means if
 
 
 
@@ -282,6 +282,9 @@ Song, et al.           Expires September 11, 2016               [Page 5]
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
+   Where xyz is either UDP or TCP, which is the client's indication of
+   how it received the underlying DNS query, and which the server will
+   use when sending the query to the far-end DNS server.  This means if
    a stub DNS client asks for TCP, then that's what the far-end DNS
    server will see, and likewise for UDP.  This header field is used for
    both request and response, for all DNS over HTTP message.
@@ -327,9 +330,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
    Since HTTP is used, all of the security concerns of HTTP are also
    present.
 
-   Servers and clients SHOULD use TLS for communication.  It provides
-   privacy and integrity for HTTP sessions.  If TLS is used, then all of
-   the security concerns of TLS are also present.
 
 
 
@@ -337,6 +337,10 @@ Song, et al.           Expires September 11, 2016               [Page 6]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   Servers and clients SHOULD use TLS for communication.  It provides
+   privacy and integrity for HTTP sessions.  If TLS is used, then all of
+   the security concerns of TLS are also present.
 
    As specified in RFC 5246 [RFC5246], both the HTTP server and client
    can be authenticated or not authenticated.  Clients SHOULD
@@ -349,7 +353,11 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
 
    Registration for a new HTTP header field: Proxy-DNS-Transport
 
-6.  References
+6.  Acknowledgments
+
+   Thanks to Bob Harold and Paul Hoffman for review
+
+7.  References
 
    [DOTSE]    and , "DNSSEC Tests of Consumer Broadband Routers",
               February 2008,
@@ -379,20 +387,16 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
               RFC5246, August 2008,
               <http://www.rfc-editor.org/info/rfc5246>.
 
-   [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines", BCP
-              152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
-              <http://www.rfc-editor.org/info/rfc5625>.
-
-
-
-
-
 
 
 Song, et al.           Expires September 11, 2016               [Page 7]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines", BCP
+              152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
+              <http://www.rfc-editor.org/info/rfc5625>.
 
    [RFC7230]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Message Syntax and Routing", RFC
@@ -434,6 +438,18 @@ Authors' Addresses
    URI:   http://www.biigroup.com/
 
 
+
+
+
+
+
+
+
+Song, et al.           Expires September 11, 2016               [Page 8]
+
+Internet-Draft          DNS wire-format over HTTP             March 2016
+
+
    Runxia Wan
    Beijing Internet Institute
    2508 Room, 25th Floor, Tower A, Time Fortune
@@ -445,4 +461,44 @@ Authors' Addresses
 
 
 
-Song, et al.           Expires September 11, 2016               [Page 8]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Song, et al.           Expires September 11, 2016               [Page 9]

--- a/draft-song-dns-wireformat-http-01.txt
+++ b/draft-song-dns-wireformat-http-01.txt
@@ -301,6 +301,9 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
    proxy then this flag should be set to TCP, as the entire response can
    always be delivered so truncation is never required.
 
+   The client MUST include this option.  If it is missing then it is an
+   error and the server should respond with HTTP code 400 (bad request).
+
 3.3.  Message Body
 
    As mentioned, the message body is DNS wire-format data.
@@ -322,14 +325,11 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
 
 4.  Security Considerations
 
+   This protocol does not introduce any new security considerations
+   since it is built on the DNS and HTTP protocols.
+
    Since this protocol transmits DNS messages, all of the security
    concerns that stub resolvers and recursive resolvers have with DNS
-   messages apply.  However, since HTTP uses TCP as the underlying
-   protocol, DNS reflection or amplification attacks are not possible.
-
-   Since HTTP is used, all of the security concerns of HTTP are also
-   present.
-
 
 
 
@@ -337,6 +337,12 @@ Song, et al.           Expires September 11, 2016               [Page 6]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   messages apply.  However, since HTTP uses TCP as the underlying
+   protocol, DNS reflection or amplification attacks are not possible.
+
+   Since HTTP is used, all of the security concerns of HTTP are also
+   present.
 
    Servers and clients SHOULD use TLS for communication.  It provides
    privacy and integrity for HTTP sessions.  If TLS is used, then all of
@@ -379,13 +385,7 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
               using XML", draft-mohan-dns-query-xml-00 (work in
               progress), September 2011.
 
-   [RFC1035]  Mockapetris, P., "Domain names - implementation and
-              specification", STD 13, RFC 1035, November 1987.
 
-   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
-              (TLS) Protocol Version 1.2", RFC 5246, DOI 10.17487/
-              RFC5246, August 2008,
-              <http://www.rfc-editor.org/info/rfc5246>.
 
 
 
@@ -393,6 +393,14 @@ Song, et al.           Expires September 11, 2016               [Page 7]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, November 1987.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246, DOI 10.17487/
+              RFC5246, August 2008,
+              <http://www.rfc-editor.org/info/rfc5246>.
 
    [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines", BCP
               152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
@@ -428,14 +436,6 @@ Authors' Addresses
    URI:   http://www.biigroup.com/
 
 
-   Shane Kerr
-   Beijing Internet Institute
-   2/F, Building 5, No.58 Jinghai Road, BDA
-   Beijing  100176
-   CN
-
-   Email: shane@biigroup.cn
-   URI:   http://www.biigroup.com/
 
 
 
@@ -450,6 +450,16 @@ Song, et al.           Expires September 11, 2016               [Page 8]
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
+   Shane Kerr
+   Beijing Internet Institute
+   2/F, Building 5, No.58 Jinghai Road, BDA
+   Beijing  100176
+   CN
+
+   Email: shane@biigroup.cn
+   URI:   http://www.biigroup.com/
+
+
    Runxia Wan
    Beijing Internet Institute
    2508 Room, 25th Floor, Tower A, Time Fortune
@@ -458,16 +468,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
 
    Email: rxwan@biigroup.cn
    URI:   http://www.biigroup.com/
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/draft-song-dns-wireformat-http-01.txt
+++ b/draft-song-dns-wireformat-http-01.txt
@@ -5,8 +5,8 @@
 Internet Engineering Task Force                                  L. Song
 Internet-Draft                                                   S. Kerr
 Intended status: Experimental                                     R. Wan
-Expires: September 1, 2016                    Beijing Internet Institute
-                                                       February 29, 2016
+Expires: September 11, 2016                   Beijing Internet Institute
+                                                          March 10, 2016
 
 
                        DNS wire-format over HTTP
@@ -33,7 +33,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 1, 2016.
+   This Internet-Draft will expire on September 11, 2016.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Song, et al.            Expires September 1, 2016               [Page 1]
+Song, et al.           Expires September 11, 2016               [Page 1]
 
-Internet-Draft          DNS wire-format over HTTP          February 2016
+Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
 Table of Contents
@@ -66,7 +66,7 @@ Table of Contents
      3.1.  Start-line  . . . . . . . . . . . . . . . . . . . . . . .   4
      3.2.  Header Fields . . . . . . . . . . . . . . . . . . . . . .   5
      3.3.  Message Body  . . . . . . . . . . . . . . . . . . . . . .   6
-   4.  Considerations on DNS over HTTPS  . . . . . . . . . . . . . .   6
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
    5.  IANA considerations . . . . . . . . . . . . . . . . . . . . .   7
    6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   8
@@ -101,17 +101,17 @@ Table of Contents
    [I-D.mohan-dns-query-xml] encoding for DNS data, in this approach
    wire-format data is wrapped with a HTTP header and transmitted on
    port 80 or 443.  This protocol is not designed with web developers or
-   advanced usage in application development in mind.  It simply serves
-   as a sort of DNS VPN, and does not introduce another format of DNS
-   data.
+   advanced usage in application development in mind (although it is
+   possible for a web browser to use this protocol to perform DNS
+   lookups, for example via JavaScript code).  The protocol is intended
+   to serve as a sort of DNS VPN, and does not introduce another format
+   of DNS data.
 
 
 
-
-
-Song, et al.            Expires September 1, 2016               [Page 2]
+Song, et al.           Expires September 11, 2016               [Page 2]
 
-Internet-Draft          DNS wire-format over HTTP          February 2016
+Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
    This memo aims to describe how the DNS binary over HTTP concept
@@ -165,9 +165,9 @@ Internet-Draft          DNS wire-format over HTTP          February 2016
 
 
 
-Song, et al.            Expires September 1, 2016               [Page 3]
+Song, et al.           Expires September 11, 2016               [Page 3]
 
-Internet-Draft          DNS wire-format over HTTP          February 2016
+Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
    3.  The proxy client connects to the proxy server and issues an HTTP
@@ -188,7 +188,7 @@ Internet-Draft          DNS wire-format over HTTP          February 2016
    back address in the same host with stub-resolver.  The proxy server
    can be implemented as a caching server as well.  It is also possible
    to use the proxy server as a regular web server at the same time that
-   is is acting as a proxy server.
+   is acting as a proxy server.
 
 3.  DNS-over-HTTP Message Format
 
@@ -221,9 +221,9 @@ Internet-Draft          DNS wire-format over HTTP          February 2016
 
 
 
-Song, et al.            Expires September 1, 2016               [Page 4]
+Song, et al.           Expires September 11, 2016               [Page 4]
 
-Internet-Draft          DNS wire-format over HTTP          February 2016
+Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
    request.  In the case of DNS query over HTTP, one approach is to
@@ -277,9 +277,9 @@ Internet-Draft          DNS wire-format over HTTP          February 2016
 
 
 
-Song, et al.            Expires September 1, 2016               [Page 5]
+Song, et al.           Expires September 11, 2016               [Page 5]
 
-Internet-Draft          DNS wire-format over HTTP          February 2016
+Internet-Draft          DNS wire-format over HTTP             March 2016
 
 
    a stub DNS client asks for TCP, then that's what the far-end DNS
@@ -295,7 +295,7 @@ Internet-Draft          DNS wire-format over HTTP          February 2016
    functionality.
 
    For a stub resolver that connect directly via HTTP to the HTTP server
-   proxy then this flag is not necessary, as the entire response can
+   proxy then this flag should be set to TCP, as the entire response can
    always be delivered so truncation is never required.
 
 3.3.  Message Body
@@ -312,31 +312,38 @@ Internet-Draft          DNS wire-format over HTTP          February 2016
    bytes length field in DNS over TCP.
 
    Since this two-byte length field is redundant, when the client proxy
-   receives a DNS message over TCP, it does NOT include the length field
+   receives a DNS message over TCP, it MUST NOT include the length field
    in the message sent to the server.  The length in the content-length
-   header is only the size of the DNS message itself, and does NOT
+   header is only the size of the DNS message itself, and MUST NOT
    include this two-byte length header.
 
-4.  Considerations on DNS over HTTPS
+4.  Security Considerations
 
-   HTTPS is recommended for communication.  It provides privacy and
-   integrity for HTTP sessions.
+   Since this protocol transmits DNS messages, all of the security
+   concerns that stub resolvers and recursive resolvers have with DNS
+   messages apply.  However, since HTTP uses TCP as the underlying
+   protocol, DNS reflection or amplification attacks are not possible.
 
-   As specified in RFC 5246 [RFC5246], both the DNS server and client
-   can be authenticated or not authenticated.  The DNS service providers
-   can decide authenticated pattern on both server and client sides
-   based on their own requirement for security and privacy.  For an open
-   resolver, clients do not require authentication.
+   Since HTTP is used, all of the security concerns of HTTP are also
+   present.
+
+   Servers and clients SHOULD use TLS for communication.  It provides
+   privacy and integrity for HTTP sessions.  If TLS is used, then all of
+   the security concerns of TLS are also present.
 
 
 
-
-
-
-Song, et al.            Expires September 1, 2016               [Page 6]
+Song, et al.           Expires September 11, 2016               [Page 6]
 
-Internet-Draft          DNS wire-format over HTTP          February 2016
+Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   As specified in RFC 5246 [RFC5246], both the HTTP server and client
+   can be authenticated or not authenticated.  Clients SHOULD
+   authenticate the certificate of the HTTP server they connect to.  The
+   DNS service providers can decide whether to authenticate the client
+   side based on their own requirement for security and privacy.  For
+   example, clients of an open resolver do not require authentication.
 
 5.  IANA considerations
 
@@ -365,38 +372,41 @@ Internet-Draft          DNS wire-format over HTTP          February 2016
               progress), September 2011.
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
-              specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
-              November 1987, <http://www.rfc-editor.org/info/rfc1035>.
+              specification", STD 13, RFC 1035, November 1987.
 
    [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
-              (TLS) Protocol Version 1.2", RFC 5246,
-              DOI 10.17487/RFC5246, August 2008,
+              (TLS) Protocol Version 1.2", RFC 5246, DOI 10.17487/
+              RFC5246, August 2008,
               <http://www.rfc-editor.org/info/rfc5246>.
 
-   [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines",
-              BCP 152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
+   [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines", BCP
+              152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
               <http://www.rfc-editor.org/info/rfc5625>.
 
+
+
+
+
+
+
+Song, et al.           Expires September 11, 2016               [Page 7]
+
+Internet-Draft          DNS wire-format over HTTP             March 2016
+
+
    [RFC7230]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
-              Protocol (HTTP/1.1): Message Syntax and Routing",
-              RFC 7230, DOI 10.17487/RFC7230, June 2014,
+              Protocol (HTTP/1.1): Message Syntax and Routing", RFC
+              7230, DOI 10.17487/RFC7230, June 2014,
               <http://www.rfc-editor.org/info/rfc7230>.
 
    [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
-              Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
-              DOI 10.17487/RFC7231, June 2014,
+              Protocol (HTTP/1.1): Semantics and Content", RFC 7231, DOI
+              10.17487/RFC7231, June 2014,
               <http://www.rfc-editor.org/info/rfc7231>.
 
-
-
-Song, et al.            Expires September 1, 2016               [Page 7]
-
-Internet-Draft          DNS wire-format over HTTP          February 2016
-
-
    [RFC7540]  Belshe, M., Peon, R., and M. Thomson, Ed., "Hypertext
-              Transfer Protocol Version 2 (HTTP/2)", RFC 7540,
-              DOI 10.17487/RFC7540, May 2015,
+              Transfer Protocol Version 2 (HTTP/2)", RFC 7540, DOI
+              10.17487/RFC7540, May 2015,
               <http://www.rfc-editor.org/info/rfc7540>.
 
    [SAC035]   ICANN Security and Stability Advisory Committee, "DNSSEC
@@ -435,14 +445,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-
-Song, et al.            Expires September 1, 2016               [Page 8]
+Song, et al.           Expires September 11, 2016               [Page 8]

--- a/draft-song-dns-wireformat-http-01.txt
+++ b/draft-song-dns-wireformat-http-01.txt
@@ -64,9 +64,9 @@ Table of Contents
    2.  Methodology and Configuration . . . . . . . . . . . . . . . .   3
    3.  DNS-over-HTTP Message Format  . . . . . . . . . . . . . . . .   4
      3.1.  Start-line  . . . . . . . . . . . . . . . . . . . . . . .   4
-     3.2.  Header Fields . . . . . . . . . . . . . . . . . . . . . .   5
+     3.2.  Header Fields . . . . . . . . . . . . . . . . . . . . . .   6
      3.3.  Message Body  . . . . . . . . . . . . . . . . . . . . . .   6
-   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
    5.  IANA considerations . . . . . . . . . . . . . . . . . . . . .   7
    6.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .   7
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
@@ -187,6 +187,10 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
        response and sends it back to the stub-resolver via previous DNS
        session (either UDP or TCP).
 
+   It is possible that these scenarios are mixed.  The server may speak
+   DNS over HTTP directly and the client use a proxy, or the other way
+   around.
+
    Note that the proxy client can be implemented listening to a loop-
    back address in the same host with stub-resolver.  The proxy server
    can be implemented as a caching server as well.  It is also possible
@@ -213,10 +217,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
    of the request method, request-target, and HTTP-version with a CRLF
    in the end.
 
-   For a DNS query over HTTP, the request is always POST [section 4.3.3
-   in RFC 7230 [RFC7230]].  Note if a GET is sent to the server, it
-   optionally returns a human-readable page showing its web server
-   environment.
 
 
 
@@ -225,6 +225,11 @@ Song, et al.           Expires September 11, 2016               [Page 4]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+   For a DNS query over HTTP, the request is always POST [section 4.3.3
+   in RFC 7230 [RFC7230]].  Note if a GET is sent to the server, it
+   optionally returns a human-readable page showing its web server
+   environment.
 
    Usually the target URI is provides explicitly by the DNS services
    provider.  Derived from the target URI, the request-target in
@@ -265,14 +270,9 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
    (server error) if some server-side problem prevented a query from
    succeeding.
 
-3.2.  Header Fields
 
-   By definition header fields are key:value pairs that can be used to
-   communicate data about the message, its payload, the target resource,
-   or the connection (for example control data).  Considering the proxy
-   configuration in scenario 2, we use a new header field:
 
-   Proxy-DNS-Transport: xyz
+
 
 
 
@@ -281,6 +281,15 @@ Song, et al.           Expires September 11, 2016               [Page 5]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
 
+
+3.2.  Header Fields
+
+   By definition header fields are key:value pairs that can be used to
+   communicate data about the message, its payload, the target resource,
+   or the connection (for example control data).  Considering the proxy
+   configuration in scenario 2, we use a new header field:
+
+   Proxy-DNS-Transport: xyz
 
    Where xyz is either UDP or TCP, which is the client's indication of
    how it received the underlying DNS query, and which the server will
@@ -320,6 +329,15 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
    Since this two-byte length field is redundant, when the client proxy
    receives a DNS message over TCP, it MUST NOT include the length field
    in the message sent to the server.  The length in the content-length
+
+
+
+
+Song, et al.           Expires September 11, 2016               [Page 6]
+
+Internet-Draft          DNS wire-format over HTTP             March 2016
+
+
    header is only the size of the DNS message itself, and MUST NOT
    include this two-byte length header.
 
@@ -330,14 +348,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
 
    Since this protocol transmits DNS messages, all of the security
    concerns that stub resolvers and recursive resolvers have with DNS
-
-
-
-Song, et al.           Expires September 11, 2016               [Page 6]
-
-Internet-Draft          DNS wire-format over HTTP             March 2016
-
-
    messages apply.  However, since HTTP uses TCP as the underlying
    protocol, DNS reflection or amplification attacks are not possible.
 
@@ -374,6 +384,16 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
               draft-bortzmeyer-dns-json-01 (work in progress), February
               2013.
 
+
+
+
+
+
+Song, et al.           Expires September 11, 2016               [Page 7]
+
+Internet-Draft          DNS wire-format over HTTP             March 2016
+
+
    [I-D.ietf-dnsop-5966bis]
               Dickinson, J., Dickinson, S., Bellis, R., Mankin, A., and
               D. Wessels, "DNS Transport over TCP - Implementation
@@ -384,15 +404,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
               Parthasarathy, M. and P. Vixie, "Representing DNS messages
               using XML", draft-mohan-dns-query-xml-00 (work in
               progress), September 2011.
-
-
-
-
-
-Song, et al.           Expires September 11, 2016               [Page 7]
-
-Internet-Draft          DNS wire-format over HTTP             March 2016
-
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, November 1987.
@@ -426,17 +437,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
 
 Authors' Addresses
 
-   Linjian Song
-   Beijing Internet Institute
-   2508 Room, 25th Floor, Tower A, Time Fortune
-   Beijing  100028
-   P. R. China
-
-   Email: songlinjian@gmail.com
-   URI:   http://www.biigroup.com/
-
-
-
 
 
 
@@ -448,6 +448,16 @@ Authors' Addresses
 Song, et al.           Expires September 11, 2016               [Page 8]
 
 Internet-Draft          DNS wire-format over HTTP             March 2016
+
+
+   Linjian Song
+   Beijing Internet Institute
+   2508 Room, 25th Floor, Tower A, Time Fortune
+   Beijing  100028
+   P. R. China
+
+   Email: songlinjian@gmail.com
+   URI:   http://www.biigroup.com/
 
 
    Shane Kerr
@@ -468,16 +478,6 @@ Internet-Draft          DNS wire-format over HTTP             March 2016
 
    Email: rxwan@biigroup.cn
    URI:   http://www.biigroup.com/
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/draft-song-dns-wireformat-http-01.xml
+++ b/draft-song-dns-wireformat-http-01.xml
@@ -385,6 +385,12 @@
     	<t>Registration for a new HTTP header field: Proxy-DNS-Transport</t>
     
     </section>
+
+  <section title="Acknowledgments">
+    <t>
+    Thanks to Bob Harold and Paul Hoffman for review
+    </t>
+  </section> <!-- Acknowledgments -->
   
   </middle>
 

--- a/draft-song-dns-wireformat-http-01.xml
+++ b/draft-song-dns-wireformat-http-01.xml
@@ -224,6 +224,10 @@
       </list>
        </t>
 
+      <t>It is possible that these scenarios are mixed. The server may
+         speak DNS over HTTP directly and the client use a proxy, or
+         the other way around.</t>
+
       <t>Note that the proxy client can be implemented listening to a
         loop-back address in the same host with stub-resolver. The
         proxy server can be implemented as a caching server as well.

--- a/draft-song-dns-wireformat-http-01.xml
+++ b/draft-song-dns-wireformat-http-01.xml
@@ -330,6 +330,11 @@
            never required.
         </t>
 
+        <t>The client MUST include this option. If it is missing then
+           it is an error and the server should respond with HTTP code
+           400 (bad request).
+        </t>
+
        </section>
 
 
@@ -356,6 +361,10 @@
       </section>
 
   <section title="Security Considerations">
+      <t>This protocol does not introduce any new security
+      considerations since it is built on the DNS and HTTP protocols.
+      </t>
+
       <t>Since this protocol transmits DNS messages, all of the
       security concerns that stub resolvers and recursive resolvers
       have with DNS messages apply. However, since HTTP uses TCP as

--- a/draft-song-dns-wireformat-http-01.xml
+++ b/draft-song-dns-wireformat-http-01.xml
@@ -153,8 +153,11 @@
         DNS data, in this approach wire-format data is wrapped with a
         HTTP header and transmitted on port 80 or 443. This protocol
         is not designed with web developers or advanced usage in
-        application development in mind. It simply serves as a sort of
-        DNS VPN, and does not introduce another format of DNS data.
+        application development in mind (although it is possible for a
+        web browser to use this protocol to perform DNS lookups, for
+        example via JavaScript code). The protocol is intended to
+        serve as a sort of DNS VPN, and does not introduce another
+        format of DNS data.
        </t>
 
       <t>This memo aims to describe how the DNS binary over HTTP
@@ -225,7 +228,7 @@
         loop-back address in the same host with stub-resolver. The
         proxy server can be implemented as a caching server as well.
         It is also possible to use the proxy server as a regular web
-        server at the same time that is is acting as a proxy
+        server at the same time that is acting as a proxy
         server.</t>
 
     </section>
@@ -322,7 +325,7 @@
         </t>
 
         <t>For a stub resolver that connect directly via HTTP to the
-           HTTP server proxy then this flag is not necessary, as the
+           HTTP server proxy then this flag should be set to TCP, as the
            entire response can always be delivered so truncation is
            never required.
         </t>
@@ -342,27 +345,38 @@
         is the same with two bytes length field in DNS over TCP. </t>
 
       <t>Since this two-byte length field is redundant, when the
-         client proxy receives a DNS message over TCP, it does NOT
+         client proxy receives a DNS message over TCP, it MUST NOT
          include the length field in the message sent to the server.
          The length in the content-length header is only the size of
-         the DNS message itself, and does NOT include this two-byte
+         the DNS message itself, and MUST NOT include this two-byte
          length header.
       </t>
 
       </section> 
       </section>
 
-  <section title="Considerations on DNS over HTTPS">
+  <section title="Security Considerations">
+      <t>Since this protocol transmits DNS messages, all of the
+      security concerns that stub resolvers and recursive resolvers
+      have with DNS messages apply. However, since HTTP uses TCP as
+      the underlying protocol, DNS reflection or amplification attacks
+      are not possible.</t>
 
-      <t>HTTPS is recommended for communication. It provides privacy
-      and integrity for HTTP sessions.</t>
+      <t>Since HTTP is used, all of the security concerns of HTTP are
+      also present.</t>
 
-      <t>As specified in  <xref target="RFC5246">RFC 5246</xref>, both the DNS
-      server and client can be authenticated or not authenticated. The
-      DNS service providers can decide authenticated pattern on both
-      server and client sides based on their own requirement for security 
-      and privacy. For an open resolver, clients do not require
-      authentication. </t>
+      <t>Servers and clients SHOULD use TLS for communication. It
+      provides privacy and integrity for HTTP sessions. If TLS is
+      used, then all of the security concerns of TLS are also
+      present.</t>
+
+      <t>As specified in  <xref target="RFC5246">RFC 5246</xref>, both
+      the HTTP server and client can be authenticated or not
+      authenticated. Clients SHOULD authenticate the certificate of
+      the HTTP server they connect to. The DNS service providers can
+      decide whether to authenticate the client side based on their
+      own requirement for security and privacy. For example, clients
+      of an open resolver do not require authentication.</t>
     
     </section>
 


### PR DESCRIPTION
I've updated the draft as follows:
- fixed typo found by Bob Harold
- made "transport:" always required, as suggested by Bob Harold
- mentioned the possibility to use DNS over HTTP in a browser, if you really want to, as suggested by Paul Hoffman
- made the language stronger when talking about the 2-byte length label in TCP, as suggested by Paul Hoffman
- expanded the security considerations, as suggested by Paul Hoffman

I had a read through RFC 3552, but I don't think most of it applies since we're basically just layering on HTTP.

I have _NOT_ addressed:
- POST vs. GET as raised by Paul Hoffman
- `/.well-known/` as suggested by Paul Hoffman

I think it's ready for an update and then I can discuss this on the list. (I think POST vs. GET has been discussed enough, but we have to talk about `/.well-known/`.
